### PR TITLE
allow custom http-client as option

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -49,3 +49,11 @@ func (a AuthBearer) SetMQTTAuth(o *mqtt.ClientOptions) {
 	o.SetUsername("bearer")
 	o.SetPassword(a.Token)
 }
+
+type AuthNone struct{}
+
+func (a AuthNone) SetHTTPAuth(r *http.Request) {
+}
+
+func (a AuthNone) SetMQTTAuth(o *mqtt.ClientOptions) {
+}

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ type Options struct {
 	Authenticator Authentication
 	APIBase       string
 	MqttOptions   *mqtt.ClientOptions
+	HTTPClient    *http.Client
 }
 
 // Client is the main client for Lynx integration
@@ -43,10 +44,13 @@ func NewClient(options *Options) *Client {
 		options.Authenticator.SetMQTTAuth(options.MqttOptions)
 		mq = mqtt.NewClient(options.MqttOptions)
 	}
-	return &Client{
-		c: &http.Client{
+	if options.HTTPClient == nil {
+		options.HTTPClient = &http.Client{
 			Timeout: time.Second * 5,
-		},
+		}
+	}
+	return &Client{
+		c:    options.HTTPClient,
 		opt:  options,
 		Mqtt: mq,
 	}


### PR DESCRIPTION
When using the [OAuth](https://github.com/golang/oauth2) library, the authentication and refresh is done for you with a new http client.

This allows a custom http client to be used, and adds a AuthNone type to delegate the auth to the underlying client.